### PR TITLE
AY-6897: Fix course youtube video

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -346,7 +346,7 @@
         <!-- VIDEO -->
          <div class="embed-container">
             <iframe
-                src="//www.youtube-nocookie.com/embed/heHA9xdXKRk?&theme=dark&color=white&autohide=2&cc_load_policy=1&modestbranding=1&showinfo=0&rel=0"
+                src="//www.youtube-nocookie.com/embed/FmUTPI4sujo?&theme=dark&color=white&autohide=2&cc_load_policy=1&modestbranding=1&showinfo=0&rel=0"
                 frameborder="0">
             </iframe>
         </div>


### PR DESCRIPTION

<img width="640" alt="image" src="https://user-images.githubusercontent.com/6786051/193537854-986eac88-fa4d-4a4d-afaa-319a4797a0f0.png">

updated to `videoId` from index page, as the same approach is used for `websites.html`

<img width="640" alt="image" src="https://user-images.githubusercontent.com/6786051/193537595-31dea5b0-902e-433e-9a56-dc4b32b697fd.png">
